### PR TITLE
Remove disutils

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:deadsnakes/ppa
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends python3.9-dev python3.9-distutils python3.9-venv
+        sudo apt-get install -y --no-install-recommends python3.9-dev python3.9-venv
         python3.9 -m pip install --upgrade pip setuptools
         python3.9 -m venv $HOME/venv-python3.9
         echo "::set-env name=VIRTUAL_ENV::$HOME/venv-python3.9"

--- a/it/__main__.py
+++ b/it/__main__.py
@@ -1,12 +1,22 @@
 import argparse
 import sys
-from distutils.util import strtobool
 from pathlib import Path
 
 from it.plugin import Plugin
 from it.reports import _prepare_result
 from it.session import Session
 from it.utils import logger, prepare_logger, traverse_paths
+
+
+def strtobool(val):
+    try:
+        if val.lower() in ('y', 'yes', 't', 'true', 'on', '1'):
+            return True
+        elif val.lower() in ('n', 'no', 'f', 'false', 'off', '0'):
+            return False
+        raise ValueError()
+    except ValueError:
+        raise argparse.ArgumentTypeError('Invalid truth value %s' % str(val))
 
 
 def prepare_parser(session):


### PR DESCRIPTION
from python 3.10 on distutils is flagged for removal,
which happened with lately released python 3.12.

As strtobool is the only functionality used from that
package, just add an inline emulation to __main__.py.